### PR TITLE
Add Apache-2.0 license and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work, excluding
+those notices that do not pertain to any part of the
+Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications
+and may provide additional or different license terms and
+conditions for use, reproduction, or distribution of Your
+modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work
+otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ This project coordinates one or more Pololu 3pi+ 2040 robots using an ESP32 as a
 
 1. **Planning** – The script maintains maps of visited cells, clue locations, and probabilities. It plans the next step with A*; costs include turns, center-ward bias for the initial lawn-mower sweep, intent reservations from a peer robot, and accumulated rewards after clues are found.
 2. **Execution** – The robot turns toward the next cell, moves one grid square, and updates its internal maps. Bumps trigger an immediate stop.
-3. **Messaging** – After each action it sends UART messages such as `status=<text>`, `visited=x,y`, `clue=x,y`, or `alert=<reason>`. An ESP32 running `searchesp32.ino` listens on UART, forwards these messages to `<clientID>/<topic>` MQTT topics, and relays any incoming MQTT commands back to the robot.
+3. **Messaging** – After each action it sends UART frames like `1.x,y;dx,dy` (position), `2.x,y` (visited), `3.x,y` (clue), `4.x,y` (alert/object), or `5.x,y` (intent). An ESP32 running `searchesp32.ino` listens on UART, publishes to MQTT topics named `<clientID><topicDigit>`, and relays any incoming MQTT commands back to the robot.
 
 ### Example message flow
 
-1. **Startup** – Robot boots, calibrates sensors, and prints `status=boot` over UART. The ESP32 publishes this to `<clientID>/status`.
-2. **Planning & movement** – Robot chooses a goal cell with A* and announces `status=planning`. Before moving, it may reserve the next cell with `intent=x,y` and then advances.
-3. **Exploration updates** – Upon entering a cell, it sends `visited=x,y`. If a line sensor detects a white intersection, it sends `clue=x,y`; any bump sensor hit results in `alert=bump`.
-4. **External commands** – A remote controller publishes messages like `status=stop` or `alert=abort` to the robot’s MQTT topics. The ESP32 forwards these over UART, and the robot reacts accordingly.
-5. **Mission end** – On mission completion or alert, the robot publishes a final `status` message and stops motors.
+1. **Startup** – Robot boots, calibrates sensors, and publishes its starting position with `1.x,y;dx,dy`.
+2. **Planning & movement** – Before moving it may reserve the next cell using `5.x,y` and then advances, reporting the move with `2.x,y`.
+3. **Exploration updates** – Clues or object hits generate `3.x,y` or `4.x,y` messages.
+4. **External commands** – MQTT messages published on `<clientID><topicDigit>` are forwarded to the robot over UART.
+5. **Mission end** – On completion or alert, the robot stops and may publish a final position.
 
 ## Components
 
-- **`pololu-astar.py`** – MicroPython program for the Pololu 3pi+ 2040 OLED. It performs a grid search, communicates over UART, and sends status, visited cells, clues, and alerts to an attached ESP32 that forwards them to MQTT.
+- **`pololu-astar.py`** – MicroPython program for the Pololu 3pi+ 2040 OLED. It performs a grid search, communicates over UART, and sends position, visited cell, clue, alert, and intent messages to an attached ESP32 that forwards them to MQTT.
 - **`searchesp32.ino`** – Arduino sketch for an ESP32 that bridges UART messages from the Pololu robot to an MQTT broker and subscribes to the same topics for commands.
 
 ## Hardware setup
@@ -49,15 +49,16 @@ This project coordinates one or more Pololu 3pi+ 2040 robots using an ESP32 as a
 1. Power both the Pololu robot and ESP32.
 2. Ensure the ESP32 connects to Wi‑Fi and the MQTT broker.
 3. Start the MicroPython script on the robot; it will plan and move using A* search and exchange messages with the ESP32 over UART.
-4. Monitor MQTT topics such as `<clientID>/status`, `<clientID>/visited`, `<clientID>/clue`, and `<clientID>/alert` to track robot activity.
+4. Monitor MQTT topics such as `<clientID>1` (position), `<clientID>2` (visited), `<clientID>3` (clue), `<clientID>4` (alert/object), and `<clientID>5` (intent) to track robot activity.
 
 ## Notes
 
 - Modify the UART pins or baud rates in both files if you use different wiring.
 - `searchesp32.ino` attempts automatic reconnection to Wi‑Fi and MQTT if the connection drops.
+- `pololu-astar.py` writes debug information to `debug-log.txt` and summary metrics to `metrics-log.txt`.
 - Use the Pololu debug LEDs and serial output for troubleshooting.
 
 ## License
 
-This project is provided as-is without a specific license. Add a license file if you intend to distribute or reuse the code.
+This project is licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file for details.
 

--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -1,3 +1,17 @@
+# Copyright 2024 the MultiPolo contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # ===========================================================
 # Pololu 3pi+ 2040 OLED — Two-Robot Adaptive Search (UART→ESP32→MQTT bridge)
 # ===========================================================

--- a/searchesp32.ino
+++ b/searchesp32.ino
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 the MultiPolo contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <WiFi.h>
 #include "ESP32MQTTClient.h"
 


### PR DESCRIPTION
## Summary
- clarify current numeric topic messaging and MQTT flow
- document debug/metric logging and add Apache-2.0 license notes
- add Apache-2.0 license headers and license file

## Testing
- `python -m py_compile pololu-astar.py`
- `arduino-cli compile searchesp32.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b517c912008327a6cedf01f705f0cb