### PR TITLE
Report start position after calibration

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -657,6 +657,9 @@ def calibrate():
     pos[0], pos[1] = START_POS
     if 0 <= pos[0] < GRID_SIZE and 0 <= pos[1] < GRID_SIZE:
         grid[idx(pos[0], pos[1])] = 2
+    update_prob_map()
+    publish_position()
+    publish_visited(pos[0], pos[1])
 
     motors_off()
     METRIC_START_TIME_MS = time.ticks_ms()
@@ -946,8 +949,6 @@ def search_loop():
     try:
         calibrate()
         update_prob_map()
-        publish_position()
-        publish_visited(pos[0], pos[1])
 
         # wait for hub start command
         while not start_signal:

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -649,6 +649,9 @@ def calibrate():
     pos[0], pos[1] = START_POS
     if 0 <= pos[0] < GRID_SIZE and 0 <= pos[1] < GRID_SIZE:
         grid[idx(pos[0], pos[1])] = 2
+    update_prob_map()
+    publish_position()
+    publish_visited(pos[0], pos[1])
 
     motors_off()
     METRIC_START_TIME_MS = time.ticks_ms()
@@ -855,8 +858,6 @@ def search_loop():
     try:
         calibrate()
         update_prob_map()
-        publish_position()
-        publish_visited(pos[0], pos[1])
 
         # wait for hub start command
         while not start_signal:


### PR DESCRIPTION
## Summary
- publish initial position and visited cell during calibration
- update probability map after calibration so the starting cell has zero probability
- remove redundant reporting in main search loop

## Testing
- `python -m py_compile pololu-nextcell.py pololu-astar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b72caccdd0832792bae6916b1a0413