### PR TITLE
Ensure start positions broadcast until hub start signal

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -950,9 +950,14 @@ def search_loop():
         calibrate()
         update_prob_map()
 
-        # wait for hub start command
+        # wait for hub start command, periodically sharing start position
+        last_pose_publish = time.ticks_ms()
         while not start_signal:
             uart_service()
+            now = time.ticks_ms()
+            if time.ticks_diff(now, last_pose_publish) >= 3000:
+                publish_position()
+                last_pose_publish = now
             time.sleep_ms(10)
         METRIC_START_TIME_MS = time.ticks_ms()
         

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -859,9 +859,14 @@ def search_loop():
         calibrate()
         update_prob_map()
 
-        # wait for hub start command
+        # wait for hub start command, periodically sharing start position
+        last_pose_publish = time.ticks_ms()
         while not start_signal:
             uart_service()
+            now = time.ticks_ms()
+            if time.ticks_diff(now, last_pose_publish) >= 3000:
+                publish_position()
+                last_pose_publish = now
             time.sleep_ms(10)
         METRIC_START_TIME_MS = time.ticks_ms()
         


### PR DESCRIPTION
## Summary
- periodically publish starting positions while waiting for hub start signal so late-joining robots learn peer poses
- process incoming UART updates during pre-start wait in both search strategies

## Testing
- `python -m py_compile pololu-nextcell.py pololu-astar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b730f11c788327a9ee28b414c3b8af