### PR TITLE
Account for peer visits in repeat metric

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -431,7 +431,7 @@ def handle_msg(line):
     Ignores:
       - other status fields we don't currently need
     """
-    global peer_intent, peer_pos, first_clue_seen, object_location, start_signal
+    global peer_intent, peer_pos, first_clue_seen, object_location, start_signal, intersection_visits
 
     # Minimal parsing: "<sender>/<topic>:<payload>"
     try:
@@ -452,7 +452,10 @@ def handle_msg(line):
             i = idx(x, y)
             if grid[i] == 0:
                 grid[i] = 2
-                debug_log('visited updated:', i)
+            prob_map[i] = 0.0
+            if (x, y) not in intersection_visits:
+                intersection_visits[(x, y)] = 1
+            debug_log('visited updated:', i)
 
     elif topic == "3":   #clue
         try:

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -427,7 +427,7 @@ def handle_msg(line):
     Ignores:
       - other status fields we don't currently need
     """
-    global peer_intent, peer_pos, first_clue_seen, object_location, start_signal
+    global peer_intent, peer_pos, first_clue_seen, object_location, start_signal, intersection_visits
 
     # Minimal parsing: "<sender>/<topic>:<payload>"
     try:
@@ -449,6 +449,8 @@ def handle_msg(line):
             if grid[i] == 0:
                 grid[i] = 2
             prob_map[i] = 0.0
+            if (x, y) not in intersection_visits:
+                intersection_visits[(x, y)] = 1
             debug_log('visited updated:', i)
 
     elif topic == "3":   #clue


### PR DESCRIPTION
## Summary
- Track peer-visited cells in `intersection_visits` so repeat counts include other robots
- Zero out probability map entries for peer-visited cells to avoid revisits

## Testing
- `python -m py_compile pololu-nextcell.py pololu-astar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b765771790832797f5d43547e5d5ae