### PR TITLE
Fix intersection visit tracking order

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -1004,8 +1004,8 @@ def search_loop():
                 time.sleep_ms(1)
 
             # Arrived → update state & publish
-            record_intersection(pos[0], pos[1])
             pos[0], pos[1] = nxt[0], nxt[1]
+            record_intersection(pos[0], pos[1])
             grid[idx(pos[0], pos[1])] = 2
             publish_position()
             publish_visited(pos[0], pos[1])

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -912,8 +912,8 @@ def search_loop():
                 time.sleep_ms(1)
 
             # Arrived → update state & publish
-            record_intersection(pos[0], pos[1])
             pos[0], pos[1] = nxt[0], nxt[1]
+            record_intersection(pos[0], pos[1])
             cell_index = idx(pos[0], pos[1])
             grid[cell_index] = 2
             prob_map[cell_index] = 0.0


### PR DESCRIPTION
## Summary
- ensure pos is updated before recording intersection in A* planner
- mirror same update order in probabilistic next-cell planner

## Testing
- `python -m py_compile pololu-astar.py pololu-nextcell.py`


------
https://chatgpt.com/codex/tasks/task_e_68b76a6b87748327b39deaa6ee9d39be