### PR TITLE
Remove unused peer intent helper

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -791,10 +791,6 @@ def centerward_step_cost(curr_x, curr_y, next_x, next_y):
             cost += CENTER_STEP * (d_curr - d_next)
     return cost
 
-def is_peer_intent_active(peer_id):
-    """True if we have a reservation from the given peer."""
-    return peer_id in peer_intent
-
 def i_should_yield(ix, iy):
     """Yield if a peer reserved or currently occupies (ix, iy)."""
     for pid, (px, py) in peer_intent.items():

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -788,10 +788,6 @@ def centerward_step_cost(curr_x, curr_y, next_x, next_y):
             cost += CENTER_STEP * (d_curr - d_next)
     return cost
 
-def is_peer_intent_active(peer_id):
-    """True if we have a reservation from the given peer."""
-    return peer_id in peer_intent
-
 def i_should_yield(ix, iy):
     """Yield if a peer reserved or currently occupies (ix, iy)."""
     for pid, (px, py) in peer_intent.items():


### PR DESCRIPTION
## Summary
- delete `is_peer_intent_active` helper from `pololu-astar.py` and `pololu-nextcell.py`
- confirm repository has no remaining references to the removed helper

## Testing
- `python -m py_compile pololu-astar.py pololu-nextcell.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5509fa88327beda5bfba60331d0