### PR TITLE
Remove unused intersection counter variable

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -565,8 +565,7 @@ def move_forward_one_cell():
       True  -> reached an intersection (no bump)
       False -> stopped due to bump or external stop condition
     """
-    global _intersection_hits, move_forward_flag
-    _intersection_hits = 0
+    global move_forward_flag
     first_loop = False
     lock_release_time = time.ticks_ms() #flag to reset start lock time
     #outter infinite loop to keep thread check for activation

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -562,8 +562,7 @@ def move_forward_one_cell():
       True  -> reached an intersection (no bump)
       False -> stopped due to bump or external stop condition
     """
-    global _intersection_hits, move_forward_flag
-    _intersection_hits = 0
+    global move_forward_flag
     first_loop = False
     lock_release_time = time.ticks_ms() #flag to reset start lock time
     #outter infinite loop to keep thread check for activation


### PR DESCRIPTION
## Summary
- drop `_intersection_hits` declaration and reset from `move_forward_one_cell`
- streamline state setup

## Testing
- `python -m py_compile pololu-nextcell.py pololu-astar.py`
- `rg _intersection_hits -n`


------
https://chatgpt.com/codex/tasks/task_e_68b7c56f34ec8327b0193fa6e601e947