### PR TITLE
Reduce sleep delay in move_forward_one_cell

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -615,7 +615,8 @@ def move_forward_one_cell():
             right = _clamp(cfg.BASE_SPEED - correction, cfg.MIN_SPD, cfg.MAX_SPD)
             motors.set_speeds(left, right)
 
-        time.sleep_ms(300)
+        # Shorter sleep to allow rapid response when move_forward_flag is set
+        time.sleep_ms(20)
 
 def calibrate():
     """Calibrate line sensors then advance to the first intersection.

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -612,7 +612,8 @@ def move_forward_one_cell():
             right = _clamp(cfg.BASE_SPEED - correction, cfg.MIN_SPD, cfg.MAX_SPD)
             motors.set_speeds(left, right)
 
-        time.sleep_ms(300)
+        # Shorter sleep to allow rapid response when move_forward_flag is set
+        time.sleep_ms(20)
 
 def calibrate():
     """Calibrate line sensors then advance to the first intersection.


### PR DESCRIPTION
## Summary
- shorten idle wait in `move_forward_one_cell` so thread wakes promptly when triggered

## Testing
- `python -m py_compile pololu-nextcell.py pololu-astar.py`
- `python - <<'PY'
import threading, time

move_forward_flag = False
woken = False

def worker():
    global move_forward_flag, woken
    while True:
        while move_forward_flag:
            woken = True
            move_forward_flag = False
        time.sleep(0.02)  # mimic 20ms delay

thread = threading.Thread(target=worker)
thread.daemon = True
thread.start()

# Allow thread to start
time.sleep(0.1)

start = time.perf_counter()
move_forward_flag = True
while not woken:
    pass
elapsed = time.perf_counter() - start
print('Wake time:', elapsed)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b7c5789a7c8327bc1ac8f838b88f45