### PR TITLE
Fix TypeError in UART result publishing

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -417,7 +417,9 @@ def publish_intent(x, y):
 
 def publish_result(msg):
     """Publish final search metrics or result to the hub."""
-    uart.write("6." + msg + "-")
+    # ``msg`` can be numeric; ensure it is converted to string before
+    # concatenation to avoid ``TypeError: can't convert 'int' object to str``.
+    uart.write("6." + str(msg) + "-")
 
 def handle_msg(line):
     """


### PR DESCRIPTION
## Summary
- Convert result messages to strings before UART transmission in `publish_result`

## Testing
- `python -m py_compile pololu-astar.py pololu-nextcell.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8fa39037883279ab2913e8022b0fa