### PR TITLE
Fix bytearray find call in search loop for MicroPython

### DIFF
--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -417,7 +417,9 @@ def publish_intent(x, y):
 
 def publish_result(msg):
     """Publish final search metrics or result to the hub."""
-    uart.write("6." + msg + "-")
+    # ``msg`` can be numeric; ensure it is converted to string before
+    # concatenation to avoid ``TypeError: can't convert 'int' object to str``.
+    uart.write("6." + str(msg) + "-")
 
 def handle_msg(line):
     """

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -882,9 +882,10 @@ def search_loop():
             gc.collect()
 
             update_prob_map()
-            # MicroPython's bytearray does not implement the "in" operator,
-            # so use find() to detect when all cells have been visited.
-            if grid.find(0) == -1:
+            # MicroPython's ``bytearray.find`` expects a bytes-like argument;
+            # passing an integer raises a ``TypeError``. Search for a null
+            # byte explicitly to detect when all cells have been visited.
+            if grid.find(b'\x00') == -1:
                 break
 
             nxt = pick_next_cell()


### PR DESCRIPTION
## Summary
- Prevent TypeError when checking for unvisited cells by searching for a null byte in the grid

## Testing
- `python -m py_compile pololu-astar.py pololu-nextcell.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8fa39037883279ab2913e8022b0fa