### PR TITLE
Exclude object from clue candidate pool

### DIFF
--- a/clue_object_generator.py
+++ b/clue_object_generator.py
@@ -18,16 +18,20 @@ def weighted_clue_locations(
     ``1 / (1 + r)``, making nearby cells more likely.
     """
 
-    weights = [1 / (1 + math.hypot(cx - obj[0], cy - obj[1])) for cx, cy in cells]
-    available = cells.copy()
-    weights_copy = weights.copy()
+    # Candidate cells exclude the object's location so it never appears as a
+    # clue. We keep a parallel list of weights for sampling.
+    available = [cell for cell in cells if cell != obj]
+    weights = [
+        1 / (1 + math.hypot(cx - obj[0], cy - obj[1]))
+        for cx, cy in available
+    ]
     clues: List[Tuple[int, int]] = []
     while len(clues) < clues_per_object and available:
-        clue = random.choices(available, weights=weights_copy, k=1)[0]
+        clue = random.choices(available, weights=weights, k=1)[0]
         clues.append(clue)
         idx = available.index(clue)
         available.pop(idx)
-        weights_copy.pop(idx)
+        weights.pop(idx)
     return clues
 
 


### PR DESCRIPTION
## Summary
- simplify candidate generation in `weighted_clue_locations` so the object's cell is never sampled

## Testing
- `python clue_object_generator.py --grid-size 5 --trials 3 --seed 1`


------
https://chatgpt.com/codex/tasks/task_e_68c5b315c42c8327b18dc826d5ffdf99