### PR TITLE
Add dual weighting schemes for clue generation

### DIFF
--- a/clue_object_generator.py
+++ b/clue_object_generator.py
@@ -11,20 +11,28 @@ def weighted_clue_locations(
     obj: Tuple[int, int],
     cells: List[Tuple[int, int]],
     clues_per_object: int,
+    mode: str = "linear",
 ) -> List[Tuple[int, int]]:
-    """Return `clues_per_object` unique clue locations weighted by distance.
+    """Return ``clues_per_object`` unique clue locations weighted by distance.
 
-    The weight for a cell at Euclidean distance ``r`` from the object is
-    ``1 / (1 + r)``, making nearby cells more likely.
+    ``mode`` selects the weighting scheme based on the Euclidean distance ``r``
+    from the object:
+
+    * ``"linear"``  – ``1 / (1 + r)``
+    * ``"square"`` – ``1 / (1 + r**2)``
     """
 
     # Candidate cells exclude the object's location so it never appears as a
     # clue. We keep a parallel list of weights for sampling.
     available = [cell for cell in cells if cell != obj]
-    weights = [
-        1 / (1 + math.hypot(cx - obj[0], cy - obj[1]))
-        for cx, cy in available
-    ]
+
+    def weight(r: float) -> float:
+        if mode == "square":
+            return 1 / (1 + r ** 2)
+        return 1 / (1 + r)
+
+    weights = [weight(math.hypot(cx - obj[0], cy - obj[1])) for cx, cy in available]
+
     clues: List[Tuple[int, int]] = []
     while len(clues) < clues_per_object and available:
         clue = random.choices(available, weights=weights, k=1)[0]
@@ -37,16 +45,21 @@ def weighted_clue_locations(
 
 def generate_trials(
     grid_size: int = 10,
-    num_trials: int = 33,
+    num_trials: int = 34,
     clues_per_object: int = 2,
 ) -> List[Dict[str, List[Tuple[int, int]]]]:
-    """Generate trial data for object and clue locations."""
+    """Generate trial data for object and clue locations.
+
+    The first 17 trials weight clues by ``1 / (1 + r)`` and the remaining 17 by
+    ``1 / (1 + r**2)``.
+    """
 
     cells = [(x, y) for x in range(grid_size) for y in range(grid_size)]
     trials = []
-    for _ in range(num_trials):
+    for i in range(num_trials):
         obj = (random.randrange(grid_size), random.randrange(grid_size))
-        clues = weighted_clue_locations(obj, cells, clues_per_object)
+        mode = "linear" if i < 17 else "square"
+        clues = weighted_clue_locations(obj, cells, clues_per_object, mode)
         trials.append({"object": obj, "clues": clues})
     return trials
 
@@ -54,7 +67,7 @@ def generate_trials(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Clue and object generator")
     parser.add_argument("--grid-size", type=int, default=10, help="grid dimension")
-    parser.add_argument("--trials", type=int, default=33, help="number of trials")
+    parser.add_argument("--trials", type=int, default=34, help="number of trials")
     parser.add_argument(
         "--seed", type=int, default=None, help="random seed for reproducibility"
     )


### PR DESCRIPTION
## Summary
- support both 1/(1+r) and 1/(1+r^2) clue distributions
- generate 34 trials: first 17 with linear weights, last 17 with inverse square weights

## Testing
- `python -m py_compile clue_object_generator.py`
- `python clue_object_generator.py --seed 0 | python -c "import sys,json;print(len(json.load(sys.stdin)))"`


------
https://chatgpt.com/codex/tasks/task_e_68c5be0437388327b4ffde63205e377f