### PR TITLE
Remove csv dependency for Pololu metrics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A helper script, **`clue_object_generator.py`**, produces random object and clue
 - Modify the UART pins or baud rates in both files if you use different wiring.
 - `searchesp32.ino` and `searchesp32_reservation.ino` attempt automatic reconnection to Wi‑Fi and MQTT if the connection drops.
 - `pololu-astar.py` and related scripts write debug information to `debug-log.txt` and summary metrics to `metrics-log.txt`.
+- The metrics file is plain text: a single header line followed by comma-separated values so it can be parsed without the `csv` module.
 - Use `clue_object_generator.py` to produce random clue/object layouts for experiments.
 - Use the Pololu debug LEDs and serial output for troubleshooting.
 

--- a/pololu-astar-reservation.py
+++ b/pololu-astar-reservation.py
@@ -45,7 +45,6 @@ import _thread
 import heapq
 import sys
 import gc
-import csv
 from array import array
 from machine import UART, Pin
 from pololu_3pi_2040_robot import robot
@@ -187,11 +186,10 @@ def metrics_log():
                 write_header = _fp.read(1) == ""
         except OSError:
             write_header = True
-        with open(METRICS_LOG_FILE, "a", newline="") as _fp:
-            writer = csv.DictWriter(_fp, fieldnames=fieldnames)
+        with open(METRICS_LOG_FILE, "a") as _fp:
             if write_header:
-                writer.writeheader()
-            writer.writerow(metrics)
+                _fp.write(",".join(fieldnames) + "\n")
+            _fp.write(",".join(str(metrics[f]) for f in fieldnames) + "\n")
     except OSError:
         pass
     return metrics

--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -45,7 +45,6 @@ import _thread
 import heapq
 import sys
 import gc
-import csv
 from array import array
 from machine import UART, Pin
 from pololu_3pi_2040_robot import robot
@@ -184,11 +183,10 @@ def metrics_log():
                 write_header = _fp.read(1) == ""
         except OSError:
             write_header = True
-        with open(METRICS_LOG_FILE, "a", newline="") as _fp:
-            writer = csv.DictWriter(_fp, fieldnames=fieldnames)
+        with open(METRICS_LOG_FILE, "a") as _fp:
             if write_header:
-                writer.writeheader()
-            writer.writerow(metrics)
+                _fp.write(",".join(fieldnames) + "\n")
+            _fp.write(",".join(str(metrics[f]) for f in fieldnames) + "\n")
     except OSError:
         pass
     return metrics

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -44,7 +44,6 @@ import _thread
 import sys
 import gc
 import random
-import csv
 from array import array
 from machine import UART, Pin
 from pololu_3pi_2040_robot import robot
@@ -182,11 +181,10 @@ def metrics_log():
                 write_header = _fp.read(1) == ""
         except OSError:
             write_header = True
-        with open(METRICS_LOG_FILE, "a", newline="") as _fp:
-            writer = csv.DictWriter(_fp, fieldnames=fieldnames)
+        with open(METRICS_LOG_FILE, "a") as _fp:
             if write_header:
-                writer.writeheader()
-            writer.writerow(metrics)
+                _fp.write(",".join(fieldnames) + "\n")
+            _fp.write(",".join(str(metrics[f]) for f in fieldnames) + "\n")
     except OSError:
         pass
     return metrics

--- a/pololu-sweep.py
+++ b/pololu-sweep.py
@@ -46,7 +46,6 @@ import _thread
 import heapq
 import sys
 import gc
-import csv
 from array import array
 from machine import UART, Pin
 from pololu_3pi_2040_robot import robot
@@ -185,11 +184,10 @@ def metrics_log():
                 write_header = _fp.read(1) == ""
         except OSError:
             write_header = True
-        with open(METRICS_LOG_FILE, "a", newline="") as _fp:
-            writer = csv.DictWriter(_fp, fieldnames=fieldnames)
+        with open(METRICS_LOG_FILE, "a") as _fp:
             if write_header:
-                writer.writeheader()
-            writer.writerow(metrics)
+                _fp.write(",".join(fieldnames) + "\n")
+            _fp.write(",".join(str(metrics[f]) for f in fieldnames) + "\n")
     except OSError:
         pass
     return metrics


### PR DESCRIPTION
## Summary
- write Pololu metrics logs using simple string joins instead of csv.DictWriter
- drop csv module import so the scripts run on MicroPython-based Pololus
- document the plain-text metrics log format in the README

## Testing
- `python -m py_compile pololu-astar.py pololu-astar-reservation.py pololu-nextcell.py pololu-sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5f343cd388327b2e03fac94f24c12