### PR TITLE
Remove redundant stop_all call in Pololu scripts

### DIFF
--- a/pololu-astar-reservation.py
+++ b/pololu-astar-reservation.py
@@ -1189,6 +1189,5 @@ try:
 finally:
     # Ensure absolutely everything is stopped
     running = False
-    stop_all()
     flash_LEDS(RED,5)
     time.sleep_ms(200)  # give RX thread time to fall out cleanly

--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -1153,6 +1153,5 @@ try:
 finally:
     # Ensure absolutely everything is stopped
     running = False
-    stop_all()
     flash_LEDS(RED,5)
     time.sleep_ms(200)  # give RX thread time to fall out cleanly

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -1085,6 +1085,5 @@ try:
 finally:
     # Ensure absolutely everything is stopped
     running = False
-    stop_all()
     flash_LEDS(RED,5)
     time.sleep_ms(200)  # give RX thread time to fall out cleanly

--- a/pololu-sweep.py
+++ b/pololu-sweep.py
@@ -1201,6 +1201,5 @@ try:
 finally:
     # Ensure absolutely everything is stopped
     running = False
-    stop_all()
     flash_LEDS(RED,5)
     time.sleep_ms(200)  # give RX thread time to fall out cleanly


### PR DESCRIPTION
## Summary
- avoid double metrics logging by removing redundant `stop_all()` call from Pololu scripts

## Testing
- `python pololu-astar.py` *(fails: No module named 'machine')*
- `python pololu-astar-reservation.py` *(fails: No module named 'machine')*
- `python pololu-nextcell.py` *(fails: No module named 'machine')*
- `python pololu-sweep.py` *(fails: No module named 'machine')*


------
https://chatgpt.com/codex/tasks/task_e_68c60125b10c83278c62383aa3f8c813