### PR TITLE
Remove leftover visited debug logging

### DIFF
--- a/pololu-astar-reservation.py
+++ b/pololu-astar-reservation.py
@@ -564,7 +564,6 @@ def handle_msg(line):
                 system_repeat_count += 1
             else:
                 system_visits[key] = 1
-            debug_log('visited updated:', i)
 
     elif topic == "3":   #clue
         try:

--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -549,7 +549,6 @@ def handle_msg(line):
                 system_repeat_count += 1
             else:
                 system_visits[key] = 1
-            debug_log('visited updated:', i)
 
     elif topic == "3":   #clue
         try:

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -538,7 +538,6 @@ def handle_msg(line):
                 system_repeat_count += 1
             else:
                 system_visits[key] = 1
-            debug_log('visited updated:', i)
 
     elif topic == "3":   #clue
         try:

--- a/pololu-sweep.py
+++ b/pololu-sweep.py
@@ -649,7 +649,6 @@ def handle_msg(line):
                 system_repeat_count += 1
             else:
                 system_visits[key] = 1
-            debug_log('visited updated:', i)
 
     elif topic == "3":   #clue
         try:


### PR DESCRIPTION
## Summary
- remove the stray `debug_log('visited updated:', ...)` statements from the visited-topic handler across all robot control scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8681c773083279e216c555d91999e