### PR TITLE
Use Manhattan distance in clue generator

### DIFF
--- a/clue_obejct_generator_manhat.py
+++ b/clue_obejct_generator_manhat.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import math
 import random
 from typing import List, Tuple, Dict
 
@@ -15,7 +14,7 @@ def weighted_clue_locations(
 ) -> List[Tuple[int, int]]:
     """Return ``clues_per_object`` unique clue locations weighted by distance.
 
-    ``mode`` selects the weighting scheme based on the Euclidean distance ``r``
+    ``mode`` selects the weighting scheme based on the Manhattan distance ``r``
     from the object:
 
     * ``"linear"``  – ``1 / (1 + r)``
@@ -31,7 +30,9 @@ def weighted_clue_locations(
             return 1 / (1 + r ** 2)
         return 1 / (1 + r)
 
-    weights = [weight(math.hypot(cx - obj[0], cy - obj[1])) for cx, cy in available]
+    weights = [
+        weight(abs(cx - obj[0]) + abs(cy - obj[1])) for cx, cy in available
+    ]
 
     clues: List[Tuple[int, int]] = []
     while len(clues) < clues_per_object and available:


### PR DESCRIPTION
## Summary
- update the Manhattan variant of the clue generator to weight distances using Manhattan distance
- document the change in the weighting description

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8d2142fc883279919360d53fcca53