### PR TITLE
Remove TODO comment sections from Pololu scripts

### DIFF
--- a/pololu-astar-reservation.py
+++ b/pololu-astar-reservation.py
@@ -51,10 +51,6 @@ from pololu_3pi_2040_robot import robot
 from pololu_3pi_2040_robot.extras import editions
 from pololu_3pi_2040_robot.buzzer import Buzzer
 
-# TODO:
-# - Ensure object reporting uses the updated location before broadcasting.
-# - Strengthen intent handling to prevent collisions.
-# - Consider enlarging the grid and adding a desktop logging tool.
 # -----------------------------
 # Robot identity & start pose
 # -----------------------------

--- a/pololu-astar.py
+++ b/pololu-astar.py
@@ -51,10 +51,6 @@ from pololu_3pi_2040_robot import robot
 from pololu_3pi_2040_robot.extras import editions
 from pololu_3pi_2040_robot.buzzer import Buzzer
 
-# TODO:
-# - Ensure object reporting uses the updated location before broadcasting.
-# - Strengthen intent handling to prevent collisions.
-# - Consider enlarging the grid and adding a desktop logging tool.
 # -----------------------------
 # Robot identity & start pose
 # -----------------------------

--- a/pololu-nextcell.py
+++ b/pololu-nextcell.py
@@ -50,10 +50,6 @@ from pololu_3pi_2040_robot import robot
 from pololu_3pi_2040_robot.extras import editions
 from pololu_3pi_2040_robot.buzzer import Buzzer
 
-# TODO:
-# - Ensure object reports use the updated location before sending.
-# - Improve intent handling to avoid collisions.
-# - Consider enlarging the grid and adding a desktop logging interface.
 # -----------------------------
 # Robot identity & start pose
 # -----------------------------

--- a/pololu-sweep.py
+++ b/pololu-sweep.py
@@ -52,10 +52,6 @@ from pololu_3pi_2040_robot import robot
 from pololu_3pi_2040_robot.extras import editions
 from pololu_3pi_2040_robot.buzzer import Buzzer
 
-# TODO:
-# - Ensure object reporting uses the updated location before broadcasting.
-# - Strengthen intent handling to prevent collisions.
-# - Consider enlarging the grid and adding a desktop logging tool.
 # -----------------------------
 # Robot identity & start pose
 # -----------------------------


### PR DESCRIPTION
## Summary
- remove the obsolete TODO comment blocks from the Pololu navigation scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d310f8408327bd17f976deab1b72